### PR TITLE
Noissue add function to fetch unique entries in column

### DIFF
--- a/src/hooks/datasets.js
+++ b/src/hooks/datasets.js
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { useStateValue } from '../contexts/OpenDataContext';
-import { findJoinable } from '../utils/socrata';
+import { findJoinable, getUniqueEntries } from '../utils/socrata';
 
 export function useTags() {
   const [{ tagList }] = useStateValue();
@@ -14,7 +14,6 @@ export function useCategories() {
 
 export function useJoinableDatasets(dataset) {
   const [{ datasets }] = useStateValue();
-  console.log(dataset);
   return useMemo(() => (dataset ? findJoinable(dataset, datasets) : []), [
     dataset,
     datasets,
@@ -37,7 +36,6 @@ export function useDatasets({ tags, term, categories, ids }) {
     }
 
     if (tags && tags.length > 0) {
-      console.log('applting');
       filteredDatasets = filteredDatasets.filter(
         (dataset) =>
           dataset.classification.domain_tags.filter((tag) => tags.includes(tag))
@@ -60,8 +58,28 @@ export function useDatasets({ tags, term, categories, ids }) {
       );
     }
 
-    console.log('after term ', filteredDatasets.length);
-    console.log('return size ', filteredDatasets.length);
     return filteredDatasets;
   }, [datasets, ids, tags, categories, term]);
+}
+
+export function useJoinColumnUniqueCount(joins) {
+  const [uniqueCounts, setUniqueCounts] = useState([]);
+  useEffect(() => {
+    let promises = [];
+    joins.forEach((j) => {
+      j.joinableColumns.forEach((col) => {
+        promises.push(
+          getUniqueEntries(j.dataset, col).then((res) => ({
+            dataset: j.dataset.resource.id,
+            col,
+            distinct: res,
+          })),
+        );
+      });
+    });
+    // This ensures that we resolve even if one of our fetch requests fail
+    promises = promises.map((p) => p.catch(() => undefined));
+    Promise.all(promises).then((result) => setUniqueCounts(result));
+  }, [joins]);
+  return uniqueCounts;
 }

--- a/src/layout/DatasetPage/DatasetPage.jsx
+++ b/src/layout/DatasetPage/DatasetPage.jsx
@@ -7,7 +7,12 @@ import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
 import { Link } from 'react-router-dom';
 import RawHTML from '../../components/RawHTML/RawHTML';
-import { useDataset, useJoinableDatasets } from '../../hooks/datasets';
+import usePagination from '../../hooks/pagination';
+import {
+  useDataset,
+  useJoinableDatasets,
+  useJoinColumnUniqueCount,
+} from '../../hooks/datasets';
 import './DatasetPage.scss';
 
 const formatDate = (date) => moment(date).format('MMMM DD, YYYY');
@@ -16,6 +21,9 @@ export default function DatasetPage({ match }) {
   const { datasetID } = match.params;
   const dataset = useDataset(datasetID);
   const joins = useJoinableDatasets(dataset);
+  const [pagedJoins, { pageButtons: joinPageButtons }] = usePagination(joins);
+
+  const joinCounts = useJoinColumnUniqueCount(pagedJoins);
   const resource = dataset?.resource;
   const pageViews = resource?.page_views;
   const classification = dataset?.classification;
@@ -30,6 +38,7 @@ export default function DatasetPage({ match }) {
   const informationAgency = domainMetadata?.find(
     ({ key }) => key === 'Dataset-Information_Agency',
   )?.value;
+
   return (
     <Container fluid className="dataset-page">
       {dataset ? (
@@ -188,18 +197,37 @@ export default function DatasetPage({ match }) {
                 <div className="dataset-joins">
                   <h3>Can be joined with</h3>
                   <ul style={{ overflowY: 'auto' }}>
-                    {joins.map((j, i) => (
+                    {pagedJoins.map((j, i) => (
                       <li key={i}>
                         <p>
-                          <Link to={`/dataset/${j.resource?.id}`}>
-                            {j.resource?.name}{' '}
+                          <Link to={`/dataset/${j.dataset.resource?.id}`}>
+                            {j.dataset.resource?.name}{' '}
                           </Link>{' '}
                           on :
                         </p>
-                        <p> {j.joinableColumns.join(', ')}</p>
+                        <p>
+                          {j.joinableColumns.map((col) => (
+                            <span>
+                              {' '}
+                              {j.dataset.resource?.name}{' '}
+                              <span style={{ fontWeight: 'bold' }}>
+                                (
+                                {`${
+                                  joinCounts.find(
+                                    (jc) =>
+                                      jc.dataset === j.dataset.resource?.id &&
+                                      col === jc.col,
+                                  )?.distinct.length
+                                },`}
+                                )
+                              </span>
+                            </span>
+                          ))}
+                        </p>
                       </li>
                     ))}
                   </ul>
+                  {joinPageButtons}
                 </div>
               </Row>
             </Col>

--- a/src/utils/socrata.js
+++ b/src/utils/socrata.js
@@ -123,6 +123,6 @@ export function getUniqueEntries(dataset, column) {
   )
     .then((r) => r.json())
     .then((r) => {
-      return r.errorCode ? [] : r.map((entry) => Object.keys(entry)[0]);
+      return r.errorCode ? [] : r.map((entry) => Object.values(entry)[0]);
     });
 }


### PR DESCRIPTION
This PR adds a function to query the socrata API for the unique entries in a column. It adds a hook to get the unique entries for a given column / dataset pair and adds these to the dataset page. 

Also adding pagination to the join table to keep things snappy.