### PR TITLE
Resolving issue with gh-pages and routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import DatasetPage from './layout/DatasetPage/DatasetPage';
 import CollectionBar from './components/CollectionBar/CollectionBar';
 import CollectionPage from './layout/CollectionPage/CollectionPage';
 import CreateCollectionModal from './components/CreateCollectionModal/CreateCollectionModal';
+import GHPagesRedirect from './components/GHPagesRedirect/GHPagesRedirect';
 
 import 'react-router-modal/css/react-router-modal.css';
 
@@ -26,6 +27,7 @@ function App() {
       <ModalContainer />
       <div className="content">
         <Router basename={process.env.PUBLIC_URL}>
+          <GHPagesRedirect />
           <Switch>
             <Route path="/" exact component={HomePage} />
             <Route path="/dataset/:datasetID" exact component={DatasetPage} />

--- a/src/components/GHPagesRedirect/GHPagesRedirect.jsx
+++ b/src/components/GHPagesRedirect/GHPagesRedirect.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+import { Redirect } from 'react-router-dom';
+
+export default function GHPagesRedirect() {
+  const [redirect, setRedirect] = useState(null);
+  useEffect(() => {
+    // This is for dealing with the 404 redirect issue on gh pages
+    const target = sessionStorage.redirect;
+    delete sessionStorage.redirect;
+
+    if (target && target !== window.location.href) {
+      let to = target;
+      if (process.env.PUBLIC_URL) {
+        to = `/${to
+          .split('/')
+          .slice(4)
+          .join('/')}`;
+      }
+      setRedirect(to);
+    }
+  }, []);
+
+  if (redirect) {
+    return <Redirect to={redirect} />;
+  }
+  return <></>;
+}


### PR DESCRIPTION
This fixes an issue with gh-pages where non root routes go to 404. This implements a custom 404 that stashes the requested router in local storage then redirects to the index page which retrieves it and navigates to the specific route.