### PR TITLE
Issue #84 - Pagination Bugfix

### DIFF
--- a/src/hooks/pagination.jsx
+++ b/src/hooks/pagination.jsx
@@ -10,7 +10,7 @@ export default function usePagination(data, perPage = 20) {
 
   useEffect(() => {
     setCurrentPageNo(0);
-  }, []);
+  }, [pages]);
 
   const pageButtons = (
     <nav>


### PR DESCRIPTION
This bug was due to us re-running the initialization useEffect each time the input to pagination changed, which would happen more than once in the lifecycle of the MultiSelect component.  By adding the empty array we ensure we only initialize the current page to 0 the first time the component is mounted.

Resolves #84 