### PR TITLE
BugFix - 132 Hide "Switch Collections" button when not appropriate 

### DIFF
--- a/src/components/CollectionTab/CollectionTab.jsx
+++ b/src/components/CollectionTab/CollectionTab.jsx
@@ -78,9 +78,11 @@ export default function CollectionTab({ visible, onDismiss }) {
                 <h3>Create a new dataset form selection</h3>
               </>
             )}
-            <button type="button" onClick={() => setTab('switch')}>
-              Switch Collection
-            </button>
+            {collections.length > 2 && (
+              <button type="button" onClick={() => setTab('switch')}>
+                Switch Collection
+              </button>
+            )}
           </div>
 
           <div className="collection-tab-current-collection">


### PR DESCRIPTION
This PR resolves #132 . Changes behavior to make sure we only show the switch collections button when it makes sense, ie if there is more than 1 collection .