### PR TITLE
Switch to lunrjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "fuse": "^0.4.0",
         "fuse.js": "^3.4.6",
         "lodash": "^4.17.15",
+        "lunr": "^2.3.8",
         "moment": "^2.24.0",
         "node-sass": "^4.13.0",
         "normalize.css": "^8.0.1",

--- a/src/hooks/useLunr.js
+++ b/src/hooks/useLunr.js
@@ -1,0 +1,32 @@
+import { useState, useRef, useEffect } from 'react';
+import lunr from 'lunr';
+
+const parameterisedPlugin = function(builder, fields) {
+  fields.forEach(function(field) {
+    builder.field(field);
+  });
+};
+function generateIndex(options, documents) {
+  return lunr(function() {
+    this.use(parameterisedPlugin, options.fields);
+
+    documents.forEach(function(doc) {
+      this.add(doc);
+    }, this);
+  });
+}
+
+export default function useLunr({ query, documents, options }) {
+  const index = useRef(null);
+  const [results, setResults] = useState([]);
+  useEffect(() => {
+    index.current = generateIndex(options, documents);
+  }, [documents, options]);
+
+  useEffect(() => {
+    if (index.current) {
+      setResults(index.current.search(query));
+    }
+  }, [query]);
+  return results;
+}

--- a/src/hooks/useLunr.js
+++ b/src/hooks/useLunr.js
@@ -2,31 +2,36 @@ import { useState, useRef, useEffect } from 'react';
 import lunr from 'lunr';
 
 const parameterisedPlugin = function(builder, fields) {
-  fields.forEach(function(field) {
-    builder.field(field);
-  });
+    fields.forEach(function(field) {
+        builder.field(field);
+    });
 };
 function generateIndex(options, documents) {
-  return lunr(function() {
-    this.use(parameterisedPlugin, options.fields);
+    return lunr(function() {
+        this.use(parameterisedPlugin, options.fields);
 
-    documents.forEach(function(doc) {
-      this.add(doc);
-    }, this);
-  });
+        documents.forEach(function(doc) {
+            this.add(doc);
+        }, this);
+    });
 }
 
 export default function useLunr({ query, documents, options }) {
-  const index = useRef(null);
-  const [results, setResults] = useState([]);
-  useEffect(() => {
-    index.current = generateIndex(options, documents);
-  }, [documents, options]);
+    const index = useRef(null);
+    const [results, setResults] = useState([]);
 
-  useEffect(() => {
-    if (index.current) {
-      setResults(index.current.search(query));
-    }
-  }, [query]);
-  return results;
+    useEffect(() => {
+        index.current = generateIndex(options, documents);
+    }, [documents.map((d) => d.id).join('_')]);
+
+    useEffect(() => {
+        if (index.current) {
+            try {
+                setResults(index.current.search(query));
+            } catch {
+                console.log('ignoring bad query format');
+            }
+        }
+    }, [query, index.current]);
+    return results;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7168,6 +7168,11 @@ lru-cache@~1.0.2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-1.0.6.tgz#aa50f97047422ac72543bda177a9c9d018d98452"
   integrity sha1-qlD5cEdCKsclQ72hd6nJ0BjZhFI=
 
+lunr@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.8.tgz#a8b89c31f30b5a044b97d2d28e2da191b6ba2072"
+  integrity sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
This PR switches our full text search from FUSE to Lunajs which seems to be a better fit. This gives us a richer query language and some speed improvements. 

Currently we are retaining FUSE and the useFUSE hook for searching in the filters.  We might move this at some point in the future. 

Next steps here would be to move the search functionality to a web worker to make it even nicer on the interface.