### PR TITLE
Caching the search index 

### DIFF
--- a/src/hooks/useLunr.js
+++ b/src/hooks/useLunr.js
@@ -2,36 +2,59 @@ import { useState, useRef, useEffect } from 'react';
 import lunr from 'lunr';
 
 const parameterisedPlugin = function(builder, fields) {
-    fields.forEach(function(field) {
-        builder.field(field);
-    });
+  fields.forEach(function(field) {
+    builder.field(field);
+  });
 };
 function generateIndex(options, documents) {
-    return lunr(function() {
-        this.use(parameterisedPlugin, options.fields);
+  return lunr(function() {
+    this.use(parameterisedPlugin, options.fields);
 
-        documents.forEach(function(doc) {
-            this.add(doc);
-        }, this);
-    });
+    documents.forEach(function(doc) {
+      this.add(doc);
+    }, this);
+  });
+}
+
+function storeIndex(index, docLength) {
+  return localStorage.setItem(
+    'searchIndex',
+    JSON.stringify({ docCount: docLength, cachedIndex: index }),
+  );
 }
 
 export default function useLunr({ query, documents, options }) {
-    const index = useRef(null);
-    const [results, setResults] = useState([]);
+  const index = useRef(null);
+  const [results, setResults] = useState([]);
 
-    useEffect(() => {
+  useEffect(() => {
+    const cachedIndexStr = localStorage.getItem('searchIndex');
+    if (cachedIndexStr) {
+      const { docCount, cachedIndex } = JSON.parse(cachedIndexStr);
+      if (docCount === documents.length || documents.length === 0) {
+        console.log('USING CACHED INDEX ', cachedIndex);
+        index.current = lunr.Index.load(cachedIndex);
+      } else {
+        console.log('REGENERATING INDEX BECAUSE DOCUMENTS CHANGED ');
         index.current = generateIndex(options, documents);
-    }, [documents.map((d) => d.id).join('_')]);
+        storeIndex(index.current, documents.length);
+      }
+    } else {
+      console.log('USING CACHED INDEX ');
 
-    useEffect(() => {
-        if (index.current) {
-            try {
-                setResults(index.current.search(query));
-            } catch {
-                console.log('ignoring bad query format');
-            }
-        }
-    }, [query, index.current]);
-    return results;
+      index.current = generateIndex(options, documents);
+      storeIndex(index.current, documents.length);
+    }
+  }, [documents, options]);
+
+  useEffect(() => {
+    if (index.current) {
+      try {
+        setResults(index.current.search(query));
+      } catch {
+        console.log('ignoring bad query format');
+      }
+    }
+  }, [query]);
+  return results;
 }


### PR DESCRIPTION
With the switch to Lunr we had a bug where the search index was building each time you navigated away form the home page and back. This was causing a performance hit esp on mobile.

The index will now only be regenerated when the number of documents change and a cached index will be used in it's place. 

This should speed everything up