### PR TITLE
Persist active portal in browser cache and in global app state

### DIFF
--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -16,7 +16,7 @@ import AboutPage from './layout/AboutPage/AboutPage';
 import CollectionsPage from './layout/CollectionsPage/CollectionsPage';
 import WelcomeModal from './components/WelcomeModal/WelcomeModal';
 import GHPagesRedirect from './components/GHPagesRedirect/GHPagesRedirect';
-import { DEFAULT_PORTAL } from './portals';
+import { DEFAULT_PORTAL, GLOBAL_PORTAL_IDENTIFIER } from './portals';
 import { ProfilePage } from './layout/ProfilePage/ProfilePage';
 import { usePortals } from './hooks/graphQLAPI';
 
@@ -36,12 +36,15 @@ function PortalRoute() {
   const portalDetails = Portals
     ? Portals.find(p => p.abbreviation === portal)
     : null;
-  if (Portals && !portalDetails) {
+  if (Portals && !portalDetails && portal !== GLOBAL_PORTAL_IDENTIFIER) {
     return <Navigate to={`/${DEFAULT_PORTAL}`} />;
   }
 
   return Portals ? (
-    <HomePage portal={Portals.find(p => p.abbreviation === portal)} />
+    <HomePage
+      portal={Portals.find(p => p.abbreviation === portal)}
+      initialGlobalSearchVal={portal === GLOBAL_PORTAL_IDENTIFIER}
+    />
   ) : (
     'Loading ...'
   );

--- a/packages/frontend/src/components/Filters/Filters.jsx
+++ b/packages/frontend/src/components/Filters/Filters.jsx
@@ -50,16 +50,16 @@ export default function Filters({
           <div className="filters-scroll-area">
             <div className="departments">
               <DepartmentSelector
-                portalId={portal.id}
+                portalId={portal?.id}
                 isGlobal={globalSearch}
               />
             </div>
             <div className="columns">
-              <ColumnSelector portalId={portal.id} isGlobal={globalSearch} />
+              <ColumnSelector portalId={portal?.id} isGlobal={globalSearch} />
             </div>
             <div className="categories">
               <CategoriesSelector
-                portalId={portal.id}
+                portalId={portal?.id}
                 isGlobal={globalSearch}
               />
             </div>

--- a/packages/frontend/src/components/PortalSelector/PortalSelector.jsx
+++ b/packages/frontend/src/components/PortalSelector/PortalSelector.jsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, gql } from '@apollo/client';
+import { useCollectionsValue } from '../../contexts/CollectionsContext';
 import PortalInfo from '../PortalInfo/PortalInfo';
 
 import './PortalSelector.scss';
@@ -21,10 +22,17 @@ export default function PortalSelector({ selectedPortal }) {
   const navigate = useNavigate();
   const { loading, data } = useQuery(AVAILABLE_PORTALS);
   const [search, setSearch] = useState('');
+  const [, dispatch] = useCollectionsValue();
 
   const selectPortal = portal => {
     setShowMenu(false);
     navigate(`/explore/${portal.abbreviation}`);
+    dispatch({
+      type: 'PORTAL_SET_ACTIVE',
+      payload: {
+        activePortalAbbreviation: portal.abbreviation,
+      },
+    });
   };
 
   const filteredPortals = useMemo(() => {

--- a/packages/frontend/src/components/SideNav/SideNav.jsx
+++ b/packages/frontend/src/components/SideNav/SideNav.jsx
@@ -9,17 +9,19 @@ import { ReactComponent as ExploreSVG } from '../../icons/explore.svg';
 import { ReactComponent as CollectionsSVG } from '../../icons/collection.svg';
 import { ReactComponent as DataClinicSVG } from '../../icons/dataClinicWhite.svg';
 import CollectionTab from '../CollectionTab/CollectionTab';
+import { GLOBAL_PORTAL_IDENTIFIER } from '../../portals';
 import { useUserCollections } from '../../hooks/collections';
 import useLoginLogout from '../../auth/useLoginLogout';
 import useCurrentUser from '../../auth/useCurrentUser';
 
 export default function SideNav() {
   const [showCollectionTab, setShowCollectionTab] = useState(false);
-  const [{ activeCollection }] = useUserCollections();
-  const { user, isAuthenticated } = useCurrentUser();
+  const [
+    { activeCollection, activePortalAbbreviation, globalPortalsAreActive },
+  ] = useUserCollections();
+  const { isAuthenticated } = useCurrentUser();
   const { login, logout } = useLoginLogout();
 
-  console.log('Active col', activeCollection);
   return (
     <nav className="side-nav">
       <Link alt="Data Clinic" className="title" to="/">
@@ -34,7 +36,11 @@ export default function SideNav() {
         }
         alt="Explore"
         exact
-        to="/explore"
+        to={`/explore/${
+          globalPortalsAreActive
+            ? GLOBAL_PORTAL_IDENTIFIER
+            : activePortalAbbreviation
+        }`}
       >
         <ExploreSVG />
         <h1>Explore</h1>

--- a/packages/frontend/src/hooks/collections.js
+++ b/packages/frontend/src/hooks/collections.js
@@ -44,8 +44,10 @@ export function useUserCollections() {
   );
 
   const combinedState = {
+    activePortalAbbreviation: state.activePortalAbbreviation,
     activeCollectionId: state.activeCollectionId,
     collections: localOrServerCollections,
+    globalPortalsAreActive: state.globalPortalsAreActive,
     activeCollection:
       state.activeCollectionId === 'pending'
         ? {

--- a/packages/frontend/src/hooks/graphQLAPI.js
+++ b/packages/frontend/src/hooks/graphQLAPI.js
@@ -1,4 +1,5 @@
 import { useQuery, gql, useMutation } from '@apollo/client';
+import { DEFAULT_PORTAL_ID } from '../portals';
 
 export const useDatasetsFromIds = ids => {
   const DatasetsFromIdsQuery = gql`
@@ -319,11 +320,11 @@ export function useCategoriesGQL(portal, { limit, page, search, isGlobal }) {
   `;
 
   const variables = {
-    portal,
     limit,
     offset: limit * page,
     search,
     isGlobal,
+    portal: portal || DEFAULT_PORTAL_ID,
   };
 
   return useQuery(getCategoriesQuery, {
@@ -360,10 +361,10 @@ export function useDepartmentsGQL(portal, { limit, page, search, isGlobal }) {
 
   const variables = {
     isGlobal,
-    portal,
     limit,
     offset: limit * page,
     search,
+    portal: portal || DEFAULT_PORTAL_ID,
   };
 
   return useQuery(GET_DEPARTMENTS_QUERY, {
@@ -399,11 +400,11 @@ export const useColumnsGQL = (portal, { limit, page, search, isGlobal }) => {
   `;
 
   const variables = {
-    portal,
     limit,
     offset: limit * page,
     search,
     isGlobal,
+    portal: portal || DEFAULT_PORTAL_ID,
   };
 
   return useQuery(getColumnsQuery, {

--- a/packages/frontend/src/portals.js
+++ b/packages/frontend/src/portals.js
@@ -9,11 +9,13 @@ import PortalConfigs from './portal_configs.json';
 export const Portals = PortalConfigs;
 
 export const DEFAULT_PORTAL = 'NYC';
+export const DEFAULT_PORTAL_ID = 'data.cityofnewyork.us';
+export const GLOBAL_PORTAL_IDENTIFIER = 'all';
 
-export const portalForDomain = (domain) =>
-  Object.values(Portals).find((p) => p.socrataDomain === domain);
+export const portalForDomain = domain =>
+  Object.values(Portals).find(p => p.socrataDomain === domain);
 
-export const iconForAdminLevel = (adminLevel) => {
+export const iconForAdminLevel = adminLevel => {
   switch (adminLevel ? adminLevel.toLocaleLowerCase() : '') {
     case 'city':
       return faCity;


### PR DESCRIPTION
Persist active portal in browser cache and in global app state keep track of global switch.

Fixes #237 

## Test plan
- Change the active portal
- Select a dataset
- Click on the "Explore" nav icon
- The home page should return to the previously selected portal. It should not default back to NYC.
- Now switch to all portals
- Click on a dataset
- Click on the "Explore" nav icon
- The home page should remember that we were looking at global portals
- Remove the global switch. We should now be back to the previously selected portal. Not defaulting to NYC.
- Add the global switch back on.
- Refresh. We should still be on global view.