### PR TITLE
Add matching categories in search results

### DIFF
--- a/packages/frontend/src/components/Dataset/Dataset.jsx
+++ b/packages/frontend/src/components/Dataset/Dataset.jsx
@@ -16,6 +16,7 @@ export default function Dataset({
   query,
   showStats = true,
   showCollectionButtons = true,
+  selectedCategories = [],
 }) {
   const formattedName = hilightMatches(dataset.name, query);
   const similarDatasets = useGetSimilarDatasets(dataset).home;
@@ -72,6 +73,17 @@ export default function Dataset({
           <span>Last Update:</span>
           {formatDate(dataset.updatedAt)}
         </div>
+        {selectedCategories && (
+          <div className="dataset-matching-categories">
+            {selectedCategories
+              .filter(cat => dataset.categories.includes(cat))
+              .map(category => (
+                <div className="dataset-category-info" key={category}>
+                  <p>{category}</p>
+                </div>
+              ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/frontend/src/components/Dataset/Dataset.scss
+++ b/packages/frontend/src/components/Dataset/Dataset.scss
@@ -110,12 +110,35 @@
   text-align: left;
   display: flex;
   flex-direction: row;
+  align-items: center;
   span {
     font-weight: bold;
     margin-right: 5px;
   }
   .update-frequency {
     margin-right: 10px;
+  }
+  .dataset-last-updated {
+    margin-right: 10px;
+  }
+  .dataset-matching-categories {
+    .dataset-category-info {
+      display: inline-block;
+      box-sizing: border-box;
+      padding: 4px;
+      border: 2px solid #e7eef7;
+      background-color: #e7eef7;
+      border-radius: 2px;
+      align-items: center;
+      justify-content: center;
+      margin-right: 10px;
+      p {
+        padding: 0px;
+        margin: 0px;
+        color: #152935;
+        margin: 0px;
+      }
+    }
   }
 }
 .dataset-title {

--- a/packages/frontend/src/hooks/graphQLAPI.js
+++ b/packages/frontend/src/hooks/graphQLAPI.js
@@ -88,6 +88,7 @@ export const useSearchDatasets = (
           updatedAt
           permalink
           department
+          categories
         }
         total
       }

--- a/packages/frontend/src/layout/HomePage/HomePage.jsx
+++ b/packages/frontend/src/layout/HomePage/HomePage.jsx
@@ -184,6 +184,7 @@ export default function HomePage({ portal, initialGlobalSearchVal }) {
                 showStats={false}
                 dataset={dataset}
                 query={searchTerm}
+                selectedCategories={selectedCategories}
               />
             ))
           )}

--- a/packages/server/src/dataset/dataset.entity.ts
+++ b/packages/server/src/dataset/dataset.entity.ts
@@ -31,6 +31,7 @@ export class Dataset {
   @Column({ nullable: true })
   department: string;
 
+  @Field(type => [String], { nullable: false })
   @Column({ type: 'simple-array', nullable: false, default: '' })
   categories: string[];
 

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -17,6 +17,7 @@ type Collection {
 }
 
 type Dataset {
+  categories: [String!]!
   collections: [Collection!]!
   createdAt: DateTime
   datasetColumns: [DatasetColumn!]!

--- a/packages/server/src/search/search.service.ts
+++ b/packages/server/src/search/search.service.ts
@@ -7,6 +7,7 @@ import {
 } from '../dataset/dataset.service';
 import { Dataset } from '../dataset/dataset.entity';
 import { ScoredDataset } from './types/ScoredDataset';
+import consoleLogObject from '../util/consoleLogObject';
 
 import '@tensorflow/tfjs-node';
 import * as use from '@tensorflow-models/universal-sentence-encoder';
@@ -242,7 +243,7 @@ export class SearchService {
       fullQuery.push(...departmentMatches);
     }
 
-    console.log('Running elasticsearch query', {
+    consoleLogObject('Running elasticsearch query', {
       index: this.configService.get('ELASTICSEARCH_INDEX'),
       query: fullQuery,
     });


### PR DESCRIPTION
## Summary

Dataset search results now show which categories match the selected filter categories.

## Screenshots or Videos (if applicable)
<img width="1702" alt="Screen Shot 2022-06-10 at 3 11 36 PM" src="https://user-images.githubusercontent.com/10645454/173134331-3c615a4a-7b93-40c6-9e51-eece08f7ee59.png">

Include screenshots or video recordings to show off your change (if applicable).

## Related Issues

#69 