### PR TITLE
Remove whitespace from searches

### DIFF
--- a/packages/frontend/src/layout/HomePage/HomePage.jsx
+++ b/packages/frontend/src/layout/HomePage/HomePage.jsx
@@ -80,7 +80,7 @@ export default function HomePage({ portal, initialGlobalSearchVal }) {
     {
       limit: datasetsPerPage,
       offset: datasetsPerPage * currentPage,
-      search: searchTerm,
+      search: searchTerm.trim(),
       datasetColumns: selectedColumns,
       categories: selectedCategories,
       departments: selectedDepartments,
@@ -92,7 +92,7 @@ export default function HomePage({ portal, initialGlobalSearchVal }) {
   const [pageNo, { pageButtons }] = usePagination({
     totalCount: totalDatasets,
     perPage: datasetsPerPage,
-    invalidators: [searchTerm, portal?.socrataDomain],
+    invalidators: [searchTerm.trim(), portal?.socrataDomain],
   });
 
   useEffect(() => {
@@ -154,10 +154,10 @@ export default function HomePage({ portal, initialGlobalSearchVal }) {
         <div className="count-and-sort">
           <p>
             <span className="bold">{numeral(totalDatasets).format('0,0')}</span>{' '}
-            datasets {searchTerm ? 'sorted by relevance' : ''}
+            datasets {searchTerm.trim() ? 'sorted by relevance' : ''}
           </p>
 
-          {searchTerm || HIDE_SORT_MENU ? null : (
+          {searchTerm.trim() || HIDE_SORT_MENU ? null : (
             <SortMenu
               options={[
                 'Name',
@@ -183,7 +183,7 @@ export default function HomePage({ portal, initialGlobalSearchVal }) {
                 key={dataset?.id}
                 showStats={false}
                 dataset={dataset}
-                query={searchTerm}
+                query={searchTerm.trim()}
               />
             ))
           )}


### PR DESCRIPTION
## Summary

Whitespace doesn't trigger a search. Ex. before " " would say 0 results found.