### PR TITLE
Deprioritize test datasets

### DIFF
--- a/packages/server/src/dataset/dataset.entity.ts
+++ b/packages/server/src/dataset/dataset.entity.ts
@@ -85,6 +85,10 @@ export class Dataset {
   @Field(type => [ScoredDataset])
   thematicallySimilarDatasets: Promise<Dataset[]>;
 
+  /**
+   * Indicates this dataset is a non-production, test database
+   * that should be deprioritized in search results
+   */
   @Field({ nullable: false })
   @Column({ nullable: false, default: false })
   isTest: boolean;

--- a/packages/server/src/dataset/dataset.entity.ts
+++ b/packages/server/src/dataset/dataset.entity.ts
@@ -84,6 +84,10 @@ export class Dataset {
 
   @Field(type => [ScoredDataset])
   thematicallySimilarDatasets: Promise<Dataset[]>;
+
+  @Field({ nullable: false })
+  @Column({ nullable: false, default: false })
+  isTest: boolean;
 }
 
 @ObjectType()

--- a/packages/server/src/dataset/dataset.service.ts
+++ b/packages/server/src/dataset/dataset.service.ts
@@ -21,6 +21,7 @@ export type DatasetForElasticSearch = {
   department: string;
   categories: string[];
   datasetColumnFields: string[];
+  isTest: boolean;
 };
 
 @Injectable()
@@ -283,6 +284,7 @@ export class DatasetService {
         'portalId',
         'department',
         'categories',
+        'isTest'
       ],
       relations: ['datasetColumns'],
       order: {

--- a/packages/server/src/portal-sync/portal-sync.service.ts
+++ b/packages/server/src/portal-sync/portal-sync.service.ts
@@ -246,6 +246,9 @@ export class PortalSyncService {
     dataset.portal = Promise.resolve(portal);
     dataset.categories = allCategories;
     dataset.downloads = resource.download_count;
+    // TODO: find a better method to classify test datasets
+    // Looking at some of the datasets with "test" in the name, it seems most of the
+    // actual test datasets have shorter names. Choosing 3 as an arbitrary cutoff.
     dataset.isTest = resource.name.toLowerCase().includes("test") && resource.name.split(" ").length <= 3
     return dataset;
   }

--- a/packages/server/src/portal-sync/portal-sync.service.ts
+++ b/packages/server/src/portal-sync/portal-sync.service.ts
@@ -246,6 +246,7 @@ export class PortalSyncService {
     dataset.portal = Promise.resolve(portal);
     dataset.categories = allCategories;
     dataset.downloads = resource.download_count;
+    dataset.isTest = resource.name.toLowerCase().includes("test") && resource.name.split(" ").length <= 3
     return dataset;
   }
 

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -25,6 +25,7 @@ type Dataset {
   description: String!
   downloads: Float
   id: String!
+  isTest: Boolean!
   metadataUpdatedAt: DateTime
   name: String!
   permalink: String

--- a/packages/server/src/search/search.service.ts
+++ b/packages/server/src/search/search.service.ts
@@ -107,6 +107,9 @@ export class SearchService {
                 columns: {
                   type: 'text',
                 },
+                isTest: {
+                  type: 'boolean',
+                },
               },
             },
           },
@@ -210,7 +213,18 @@ export class SearchService {
     };
     const matchAll = { match_all: {} };
 
-    const query = search && search.length > 0 ? matchQuery : matchAll;
+    // deprioritize test datasets
+    const query = {
+      boosting: {
+        positive: (search && search.length > 0 ? matchQuery : matchAll),
+        negative: {
+          match: {
+            isTest: true
+          }
+        },
+        negative_boost: 0.01
+      }
+    };
     const fullQuery: any[] = [query];
 
     // add portal query
@@ -413,6 +427,7 @@ export class SearchService {
               department: item.department,
               categories: item.categories,
               columns: item.datasetColumnFields,
+              isTest: item.isTest
             },
           );
         } catch (err) {


### PR DESCRIPTION
## Summary

Deprioritize test datasets in search results. Can continue to tweak the way we classify which datasets are considered test.

## Screenshots or Videos (if applicable)
<img width="1253" alt="Screen Shot 2022-06-13 at 9 18 07 AM" src="https://user-images.githubusercontent.com/10645454/173363710-670b7659-f818-4f26-be24-9f0889851b53.png">

