### PR TITLE
URL encode collection name

### DIFF
--- a/packages/frontend/src/layout/CollectionPage/CollectionPage.jsx
+++ b/packages/frontend/src/layout/CollectionPage/CollectionPage.jsx
@@ -26,7 +26,9 @@ const EMPTY_COLLECTION = {
 function getShareableURLForUnauthenticated(collectionName, datasetIds) {
   const urlOrigin = window.location.origin;
   const datasetIdsStr = datasetIds.join(',');
-  return `${urlOrigin}/collection/${collectionName}/${datasetIdsStr}`;
+  return `${urlOrigin}/collection/${encodeURIComponent(
+    collectionName,
+  )}/${datasetIdsStr}`;
 }
 
 // TODO: $CollectionsManagement - make shareable URLs for authenticated users work


### PR DESCRIPTION

## Summary

use `encodeURIComponent()` on collection name to prevent `/`s from breaking the `<Route>`

## Screenshots or Videos (if applicable)

Local examples of the change:
<img width="521" alt="image" src="https://user-images.githubusercontent.com/444765/178605570-5c3a7d6a-d9d8-4a29-82d2-641a0e310c6f.png">
<img width="501" alt="image" src="https://user-images.githubusercontent.com/444765/178605590-79826339-8d3b-49e5-b0b7-337431443645.png">

For a quick live look at how this might work, here's a link from the original error that has been manually URL encoded (`/` => `%2F`) https://scout.tsdataclinic.com/collection/OPHC%2FMOCTO%20Open%20Data/8h5p-ccrz,uk7t-q4s9,9ck8-hj3u,bzxi-2tsw,bvug-v3mm,r8mb-budb,s6dm-mdan,ibip-ftv5,4c8i-cnte,5c4s-jwtq,ayeb-p4mv,ek5y-zcyf,csut-3wpr,pr5n-ucgi,qk6i-zcht,ezds-sqp6,kwvk-z7i9,8h9b-rp9u,44t3-dj6x,rear-wh5i,qybk-bjjc,395v-hkhg,v9sd-nunw,gpwd-npar,erm2-nwe9,tdd6-3ysr 

## Related Issues

Closes #142 

## Test Plan

Please describe the exact steps you followed to test your change. Be as clear as possible so a reviewer can follow the same steps. List what UI interactions are needed, or if there are automated tests then list what should be run. For example:

1. Create a collection with a `/` in the name
2. Copy that link 
3. Open it in a new tab
4. Verify that it points point you to the collection you just created
5. 
## Checklist Before Requesting a Review

- [ ] I have performed a self-review of my code
- [ ] My code follows the Style Guidelines and Best Practices outlined in the project wiki
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation, if applicable
- [ ] My change generates no new warnings or failed tests
- [ ] If it is a core feature, I have added thorough tests
- [ ] I have implemented analytics, if applicable
