### PR TITLE
show Add To Collection button if loading collection from URL

### DIFF
--- a/packages/frontend/src/layout/CollectionPage/CollectionPage.jsx
+++ b/packages/frontend/src/layout/CollectionPage/CollectionPage.jsx
@@ -145,7 +145,7 @@ export default function CollectionPage() {
       <div className="collection-content">
         {datasets.map(dataset => (
           <Dataset
-            showCollectionButtons={false}
+            showCollectionButtons={loadingCollectionFromURL}
             viewInOpenPortal
             key={dataset.id}
             dataset={dataset}

--- a/packages/frontend/src/layout/CollectionPage/CollectionPage.jsx
+++ b/packages/frontend/src/layout/CollectionPage/CollectionPage.jsx
@@ -145,7 +145,7 @@ export default function CollectionPage() {
       <div className="collection-content">
         {datasets.map(dataset => (
           <Dataset
-            showCollectionButtons={loadingCollectionFromURL}
+            showCollectionButtons
             viewInOpenPortal
             key={dataset.id}
             dataset={dataset}


### PR DESCRIPTION
i want to see if this makes sense, so i'll do a fuller PR message later 

the change i made uses `loadingCollectionFromURL` to determine if the collection button should be shown. this means that:

- you won't see the Add to Collection button on datasets on your own 'collections' page
    - imo, this raises the point that we might want the button there, since there is no way to remove items from the collections page
![image](https://user-images.githubusercontent.com/444765/179618407-ce5da1c7-6edb-478b-b9e5-207a563f42dc.png)

- you will see the Add to Collection button on datasets on a collections page shared with you — including your own
    - imo, this raises the point that we might want to rethink how the sharing URLs work because
        1. we're not checking to see if somebody is auth'd into a collection, just that they have the shareable link.
        2. the URL schema seems determines what somebody sees in the dataset list, not the actual db. delete some IDs arbitrarily from a shared link to see what that means
![image](https://user-images.githubusercontent.com/444765/179618794-7d63b0d3-0b6f-4a56-b6f9-fe64df659471.png)

those last few points are probably bigger issues, and i think for just getting the button on the page, this change should probably be enough. my instinct is we might want to just leave the Add to Collections button on all the datasets though, no matter where you're seeing it