### PR TITLE
Focus failures

### DIFF
--- a/packages/frontend/src/components/Dataset/Dataset.jsx
+++ b/packages/frontend/src/components/Dataset/Dataset.jsx
@@ -33,7 +33,7 @@ export default function Dataset({
           <p>{dataset.department}</p>
         </div>
 
-        <DatasetLink className="title" dataset={dataset}>
+        <DatasetLink className="data-link-title title" dataset={dataset}>
           <h2>{formattedName}</h2>
         </DatasetLink>
         {dataset.permalink}

--- a/packages/frontend/src/components/Dataset/Dataset.scss
+++ b/packages/frontend/src/components/Dataset/Dataset.scss
@@ -1,6 +1,11 @@
 .dataset {
   display: grid;
 
+  .data-link-title{
+    &:focus-visible{
+      outline:3px solid #000;
+    }
+  }
   button {
     height: 24px;
     width: 100%;

--- a/packages/frontend/src/components/Dataset/Dataset.scss
+++ b/packages/frontend/src/components/Dataset/Dataset.scss
@@ -1,9 +1,9 @@
 .dataset {
   display: grid;
 
-  .data-link-title{
-    &:focus-visible{
-      outline:3px solid #000;
+  .data-link-title {
+    &:focus-visible {
+      outline: 3px solid #000;
     }
   }
   button {

--- a/packages/frontend/src/layout/HomePage/HomePage.jsx
+++ b/packages/frontend/src/layout/HomePage/HomePage.jsx
@@ -130,6 +130,7 @@ export default function HomePage({ portal, initialGlobalSearchVal }) {
           </div>
 
           <Switch
+            className="portal-switch"
             checked={globalSearch}
             onChange={isOn => {
               setGlobalSearch(isOn);

--- a/packages/frontend/src/layout/HomePage/HomePage.scss
+++ b/packages/frontend/src/layout/HomePage/HomePage.scss
@@ -134,3 +134,9 @@ $LightGrey: #b2b2b2;
   box-sizing: border-box;
   padding: 10px 20px;
 }
+
+.portal-switch{
+  &:focus-visible{
+    outline:5px solid red;
+  } 
+}

--- a/packages/frontend/src/layout/HomePage/HomePage.scss
+++ b/packages/frontend/src/layout/HomePage/HomePage.scss
@@ -137,6 +137,6 @@ $LightGrey: #b2b2b2;
 
 .portal-switch{
   &:focus-visible{
-    outline:5px solid red;
+    outline:3px solid #000;
   } 
 }


### PR DESCRIPTION
## Summary

Please include a summary of the changes. Also include relevant motivation and context. List any dependencies that are required for this change.

Keyboard users who use the tab key to navigate through page aren't able to see which dataset they are focused on on the page. The elements ARE focused but not visibly; updated to include outline for visual tracking.

## Screenshots or Videos (if applicable)

Include screenshots or video recordings to show off your change (if applicable).

Attached screenshots of dataset links, before AND after outline added.
![Dataset Link With Outline](https://user-images.githubusercontent.com/70827740/182456413-9ca1119f-0dbd-4cc9-ad29-c6db86b58654.jpeg)
<img width="1440" alt="Before Dataset Link Outline" src="https://user-images.githubusercontent.com/70827740/182456424-5b7493c6-881a-4a50-93c6-a7a631357be5.png">

## Related Issues

List the related issues to this change. For example, `Closes #xyz`

Closes #306 

## Test Plan

Please describe the exact steps you followed to test your change. Be as clear as possible so a reviewer can follow the same steps. List what UI interactions are needed, or if there are automated tests then list what should be run. For example:

1. Go to: https://scout.tsdataclinic.com/explore/NYC
2. Advance through screen using Tab key to 1st dataset link.
3. Unable to see where I was on the page as there's no outline to indicate focus.
4. Added outline to dataset link to allow for visual tracking of focused element.

## Checklist Before Requesting a Review

- [ ] I have performed a self-review of my code
- [ ] My code follows the Style Guidelines and Best Practices outlined in the project wiki
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation, if applicable
- [ ] My change generates no new warnings or failed tests
- [ ] If it is a core feature, I have added thorough tests
- [ ] I have implemented analytics, if applicable


