### PR TITLE
Click collection card

### DIFF
--- a/packages/frontend/src/components/CollectionCard/CollectionCard.jsx
+++ b/packages/frontend/src/components/CollectionCard/CollectionCard.jsx
@@ -50,8 +50,25 @@ export default function CollectionCard({ collection }) {
     }
   };
 
+  const onClickCard = () => {
+    window.location.href = `/collection/${collection.id}`;
+  };
+
+  const onCardFocusEnter = event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      window.location.href = `/collection/${collection.id}`;
+    }
+  };
+
   return (
-    <div className="collection-card" css="position: relative">
+    <div
+      className="collection-card"
+      css="position: relative"
+      onClick={onClickCard}
+      onKeyDown={onCardFocusEnter}
+      role="link"
+      tabIndex={0}
+    >
       <div className="custom-column left">
         <h3>
           <Link to={`/collection/${collection.id}`}>{collection.name}</Link>

--- a/packages/frontend/src/components/CollectionCard/CollectionCard.jsx
+++ b/packages/frontend/src/components/CollectionCard/CollectionCard.jsx
@@ -54,6 +54,7 @@ export default function CollectionCard({ collection }) {
     window.location.href = `/collection/${collection.id}`;
   };
 
+  // If you press space or enter it will send you to the collection page (same as click)
   const onCardFocusEnter = event => {
     if (event.key === 'Enter' || event.key === ' ') {
       window.location.href = `/collection/${collection.id}`;
@@ -61,6 +62,11 @@ export default function CollectionCard({ collection }) {
   };
 
   return (
+    /**
+     * onClick sends you to the collection page
+     * onKeyDown and tabIndex are required by React to allow pages to be navigated by pressing tab
+     * tabIndex of 0 allows this div to be tab navigated to
+     */
     <div
       className="collection-card"
       css="position: relative"


### PR DESCRIPTION
## Summary

I don't think this change is correct because the linter made changes to my working copy which I didn't include here, one of which was deleting the App.jsx file. However, it did work locally before I ran git commit. 

Please do not merge this; I am trying to learn how to develop for Scout.

## Screenshots or Videos (if applicable)

It behaves the same as before, but if you click on the card itself, it also brings you to the collection page. Back button works still.

## Related Issues

Related to #259. Thank you for listing "good first issue" issues.

## Test Plan

- Start Scout
- Create collection(s)
- Go to my collections page
- Click on collection card (not the link)
- Press back on browser

## Checklist Before Requesting a Review

- [Yes] I have performed a self-review of my code
- [Did not see any] My code follows the Style Guidelines and Best Practices outlined in the project wiki
- [Yes] I have commented my code, particularly in hard-to-understand areas
- [No] I have made changes to the documentation, if applicable
- [No] My change generates no new warnings or failed tests
- [No] If it is a core feature, I have added thorough tests
- [No] I have implemented analytics, if applicable
