### PR TITLE
Make entire Collection card clickable

### DIFF
--- a/packages/frontend/src/components/CollectionCard/CollectionCard.jsx
+++ b/packages/frontend/src/components/CollectionCard/CollectionCard.jsx
@@ -21,7 +21,10 @@ export default function CollectionCard({ collection }) {
 
   const onDismissModal = () => setShowDeleteConfirmModal(false);
 
-  const onRequestDelete = () => {
+  const onRequestDelete = event => {
+    // Prevent the Card's link from triggering when Delete is clicked
+    event.preventDefault();
+    event.stopPropagation();
     setShowDeleteConfirmModal(true);
   };
 
@@ -51,43 +54,43 @@ export default function CollectionCard({ collection }) {
   };
 
   return (
-    <div className="collection-card" css="position: relative">
-      <div className="custom-column left">
-        <h3>
-          <Link to={`/collection/${collection.id}`}>{collection.name}</Link>
-        </h3>
-        <div className="collection-stats">
-          <span>
-            {pluralize('dataset', collection.datasetIds?.length ?? 0, true)}
-          </span>
+    <>
+      <Link to={`/collection/${collection.id}`} className="collection-card">
+        <div className="custom-column left">
+          <h3>{collection.name}</h3>
+          <div className="collection-stats">
+            <span>
+              {pluralize('dataset', collection.datasetIds?.length ?? 0, true)}
+            </span>
+          </div>
         </div>
-      </div>
-      <div className="custom-column right">
-        <button
-          css={`
-            background: none;
-            position: absolute;
-            right: 4px;
-            top: -6px;
-            width: auto;
-          `}
-          onClick={onRequestDelete}
-          type="button"
-        >
-          <FontAwesomeIcon
+        <div className="custom-column right">
+          <button
             css={`
-              color: #8eacd1;
-              font-size: 15px;
-              transition: all 250ms;
-              &:hover {
-                color: #657790;
-              }
+              background: none;
+              position: absolute;
+              right: 4px;
+              top: -6px;
+              width: auto;
             `}
-            size="1x"
-            icon={faTrash}
-          />
-        </button>
-      </div>
+            onClick={onRequestDelete}
+            type="button"
+          >
+            <FontAwesomeIcon
+              css={`
+                color: #8eacd1;
+                font-size: 15px;
+                transition: all 250ms;
+                &:hover {
+                  color: #657790;
+                }
+              `}
+              size="1x"
+              icon={faTrash}
+            />
+          </button>
+        </div>
+      </Link>
       {showDeleteConfirmModal ? (
         <Modal isOpen onDismiss={onDismissModal}>
           <p css="font-size: 1.4rem">
@@ -114,6 +117,6 @@ export default function CollectionCard({ collection }) {
           </div>
         </Modal>
       ) : null}
-    </div>
+    </>
   );
 }

--- a/packages/frontend/src/components/CollectionCard/CollectionCard.scss
+++ b/packages/frontend/src/components/CollectionCard/CollectionCard.scss
@@ -1,14 +1,26 @@
 .collection-card {
     background-color: white;
-    padding: 12px 20px 12px 20px;
-    box-sizing: border-box;
-    display: table;
-    width: 100%;
-    flex-direction: column;
     border-radius: 1px;
     border: 1px solid #c5cede;
+    box-sizing: border-box;
     box-shadow: 1px 1px 2px rgba(90, 117, 152, 0.3);
+    display: table;
+    flex-direction: column;
+    position: relative;
+    padding: 12px 20px 12px 20px;
+    transition: all 200ms;
+    width: 100%;
+
+    &:hover {
+        box-shadow: 1px 3px 10px rgba(90, 117, 152, 0.4);
+    }
+
+    &:focus-visible {
+        border: 2px solid blue;
+    }
+
     .collection-stats {
+        color: #152935;
         font-weight: 700;
         display: flex;
         flex-direction: row;
@@ -25,10 +37,13 @@
     }
 
     h3 {
-        color: #152935;
         font-size: 14px;
         font-weight: 700;
         margin-bottom: 20px;
+        transition: color 200ms;
+        &:hover {
+            color: #40a9ff;
+        }
     }
     button {
         display: block;


### PR DESCRIPTION
## Summary

This change makes the entire Collection card clickable.
We do this by using the `<Link>` tag as the top-level node for the Card. Using a Link tag allows us to take advantage of its builtin benefits:
- Ability to tab to the card
- Ability to click into the link by pressing Enter on the keyboard
- Use react-router's browser history management without needing to force a refresh

I also added some CSS changes here to add some hover effects when the card or card title is moused over.

## Screenshots or Videos (if applicable)
![Screen Shot 2022-10-04 at 5 50 45 PM](https://user-images.githubusercontent.com/1126088/193936965-1878f943-c6af-43e1-acf3-ada8ad535f61.png)


## Related Issues

Closes #259

## Test Plan

1. Create a new collection
2. Go to "My Collections"
3. Click anywhere on the card to access the collection. It should work.
4. Go back. Now click on the title. The title should still work as a link.
5. Go back. Click on the trash can icon. This should **not** trigger the Collection link, instead the confirmation modal should pop up asking if we're sure if we want to delete.

## Checklist Before Requesting a Review

- [ x ] I have performed a self-review of my code
- [ x ] My code follows the Style Guidelines and Best Practices outlined in the project wiki
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made changes to the documentation, if applicable
- [ x ] My change generates no new warnings or failed tests
- [ ] If it is a core feature, I have added thorough tests
- [ ] I have implemented analytics, if applicable
