### PR TITLE
Fixing cosineSimilarity call so that it works according to the OpenSearch API

### DIFF
--- a/packages/server/src/search/search.service.ts
+++ b/packages/server/src/search/search.service.ts
@@ -210,7 +210,7 @@ export class SearchService {
               query: query,
               script: {
                 source:
-                  "(cosineSimilarity(params.query_vector, 'vector') + 1.0)/2.0",
+                  "(cosineSimilarity(params.query_vector, doc['vector']) + 1.0)/2.0",
                 params: { query_vector: Array.from(embedding) },
               },
             },


### PR DESCRIPTION
## Summary

Thematic similarity results were not loading for any datasets. This bug did not occur locally (where we use elasticsearch in the docker-compose), only in production (where we use AWS OpenSearch). The discrepancy is that the API for Elasticsearch's `cosineSimilarity` and OpenSearch's `cosineSimilarity` have a minor difference. Elasticsearch expects a field name, whereas OpenSearch expects the vector. Fortunately, Elasticsearch's `cosineSimilarity` function also works if you pass a full vector so we could just use the OpenSearch API for this function:
```
cosineSimilarity(vector, doc['vector'])
```
https://opensearch.org/docs/latest/search-plugins/knn/painless-functions/
https://github.com/opensearch-project/k-NN/blob/c7379f8a43508a7ebb92a895581a292818b4d3aa/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java#L163

## Screenshots or Videos (if applicable)

n/a

## Related Issues

Fixes #325 


## Test Plan

1. Load any dataset
2. Verify that thematic similarity tab now loads

## Checklist Before Requesting a Review

- [x] I have performed a self-review of my code
- [x] My code follows the Style Guidelines and Best Practices outlined in the project wiki
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation, if applicable
- [x] My change generates no new warnings or failed tests
- [ ] If it is a core feature, I have added thorough tests
- [ ] I have implemented analytics, if applicable
