### PR TITLE
Changed from dense_vector to knn_vector

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "seed-database-full-new": "UPDATE_ON_BOOT=true LAST_METADATA_UPDATE_DATE=1970-01-01 RECREATE_ELASTICSEARCH_INDEX=true nest start",
     "seed-database-full-refresh": "UPDATE_ON_BOOT=true RECREATE_ELASTICSEARCH_INDEX=false nest start",
-    "seed-database-dev": "LAST_METADATA_UPDATE_DATE=2022-01-01 PORTAL_OVERRIDE_LIST=data.cityofnewyork.us,data.cityofchicago.org,data.nashville.gov RECREATE_ELASTICSEARCH_INDEX=false UPDATE_ON_BOOT=true nest start",
+    "seed-database-dev": "LAST_METADATA_UPDATE_DATE=2022-01-01 PORTAL_OVERRIDE_LIST=data.cityofnewyork.us,data.cityofchicago.org RECREATE_ELASTICSEARCH_INDEX=false UPDATE_ON_BOOT=true nest start",
     "sync-schema": "yarn run typeorm schema:sync",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/server/src/search/search.service.ts
+++ b/packages/server/src/search/search.service.ts
@@ -144,8 +144,8 @@ export class SearchService {
                   type: 'text',
                 },
                 vector: {
-                  type: 'dense_vector',
-                  dims: 512,
+                  type: 'knn_vector',
+                  dimension: 512,
                 },
                 department: {
                   type: 'text',


### PR DESCRIPTION
AWS OpenSearch does not support `dense_vector` for KNN search and instead expects `knn_vector` type