### PR TITLE
Handle soft-deleted datasets in Elasticsearch

### DIFF
--- a/packages/server/src/dataset/dataset.service.ts
+++ b/packages/server/src/dataset/dataset.service.ts
@@ -7,7 +7,7 @@ import {
   CategoryCount,
 } from './dataset.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MoreThanOrEqual, Repository, In } from 'typeorm';
+import { IsNull, MoreThanOrEqual, Repository, In } from 'typeorm';
 import { Portal } from '../portals/portal.entity';
 import { SearchService } from '../search/search.service';
 import { DatasetColumn } from '../dataset-columns/dataset-column.entity';
@@ -306,13 +306,14 @@ export class DatasetService {
     portalIds?: string[],
     lastMetadataUpdateDate: string = '1970-01-01',
   ): Promise<DatasetForElasticSearch[]> {
-    const metadataUpdateDateFilter = {
+    const baseWhereFilter = {
       metadataUpdatedAt: MoreThanOrEqual(lastMetadataUpdateDate),
+      deletedAt: IsNull(),
     };
 
     const whereClause = portalIds
-      ? { ...metadataUpdateDateFilter, portalId: In(portalIds) }
-      : metadataUpdateDateFilter;
+      ? { ...baseWhereFilter, portalId: In(portalIds) }
+      : baseWhereFilter;
 
     const datasets = await this.datasetRepo.find({
       select: [

--- a/packages/server/src/dataset/dataset.service.ts
+++ b/packages/server/src/dataset/dataset.service.ts
@@ -7,7 +7,13 @@ import {
   CategoryCount,
 } from './dataset.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, MoreThanOrEqual, Repository, In } from 'typeorm';
+import {
+  FindConditions,
+  IsNull,
+  MoreThanOrEqual,
+  Repository,
+  In,
+} from 'typeorm';
 import { Portal } from '../portals/portal.entity';
 import { SearchService } from '../search/search.service';
 import { DatasetColumn } from '../dataset-columns/dataset-column.entity';
@@ -257,7 +263,10 @@ export class DatasetService {
   /**
    * Get all the dataset ids that exist in a given portal
    */
-  async getAllDatasetIds(portalId: string): Promise<string[]> {
+  async getAllDatasetIds(
+    portalId: string,
+    where?: FindConditions<Dataset>,
+  ): Promise<string[]> {
     const pageSize = 300;
     const numDatasets = await this.datasetRepo.count({
       where: { portalId },
@@ -270,6 +279,7 @@ export class DatasetService {
           select: ['id'],
           where: {
             portalId,
+            ...where,
           },
           take: pageSize,
           skip: pageSize * pageIdx,
@@ -382,13 +392,17 @@ export class DatasetService {
     });
   }
 
-  createOrUpdate(dataset: Dataset) {
-    return this.datasetRepo.save(dataset);
+  async createOrUpdate(dataset: Dataset) {
+    const savedDataset = await this.datasetRepo.save(dataset);
+    // the `save()` operation doesn't return the `deletedAt` field due to a
+    // TypeORM bug, so we `findOne` operation to get this dataset so we can
+    // make sure all columns get returned.
+    return this.datasetRepo.findOne(savedDataset.id, { withDeleted: true });
   }
 
   /** Restore a soft-deleted dataset */
   restoreDataset(dataset: Dataset) {
-    return this.datasetRepo.restore(dataset);
+    return this.datasetRepo.restore(dataset.id);
   }
 
   async deleteDatasets(datasetIds: string[]) {

--- a/packages/server/src/portal-sync/portal-sync.service.ts
+++ b/packages/server/src/portal-sync/portal-sync.service.ts
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { Get, Injectable } from '@nestjs/common';
 import { Cron, Timeout } from '@nestjs/schedule';
+import { Not, IsNull } from 'typeorm';
 import { Subject } from 'rxjs';
 import fetch from 'node-fetch';
 import { PortalService } from '../portals/portal.service';
@@ -400,7 +401,7 @@ export class PortalSyncService {
             dataset,
           );
 
-          // restore the dataset if it is "undeleted" now
+          // restore the dataset if it was previously deleted
           if (savedDataset.deletedAt) {
             this.datasetService.restoreDataset(dataset);
           }
@@ -424,8 +425,8 @@ export class PortalSyncService {
     const idsInSocrata = new Set(
       flattenedDatasets.map(dataset => dataset.resource.id),
     );
-    const idsInDb = await this.datasetService.getAllDatasetIds(portal.id);
-    const idsToDelete = idsInDb.filter(id => !idsInSocrata.has(id));
+    const idsInDB = await this.datasetService.getAllDatasetIds(portal.id);
+    const idsToDelete = idsInDB.filter(id => !idsInSocrata.has(id));
     if (idsToDelete.length > 0) {
       console.log(`Found ${idsToDelete.length} datasets to delete`);
 


### PR DESCRIPTION
## Summary

- Remove soft-deleted datasets from Elasticsearch
- Prevent re-adding soft-deleted datasets to Elasticsearch on successive portal syncs
- Recover soft-deleted datasets when they are seen in Socrata again so they can get added back to Elasticsearch on that portal sync

## Screenshots or Videos (if applicable)

n/a

## Related Issues

Closes #343 

## Test Plan

1. Verify soft-deleted datasets are removed from Elasticsearch
2. Verify soft-deleted datasets don't get reinserted to Elasticsearch on successive portal syncs
3. Verify that a previously soft-deleted dataset gets recovered (in both postgres and elasticsearch) when it is seen in Socrata again

## Checklist Before Requesting a Review

- [x] I have performed a self-review of my code
- [x] My code follows the Style Guidelines and Best Practices outlined in the project wiki
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation, if applicable
- [x] My change generates no new warnings or failed tests
- [ ] If it is a core feature, I have added thorough tests
- [ ] I have implemented analytics, if applicable
