### PR TITLE
fix(portal-sync): update spelling for Connecticut (state)

### DIFF
--- a/packages/server/src/portal-sync/portal-details-lookup.ts
+++ b/packages/server/src/portal-sync/portal-details-lookup.ts
@@ -787,7 +787,7 @@ export const PortalExternalInfo = {
   'data.ct.gov': {
     logo:
       'https://data.ct.gov/api/assets/58B1625E-0B18-457A-A5B6-07287B76E1B3?Data_Portal.png',
-    name: 'Conneticut',
+    name: 'Connecticut',
     adminLevel: 'state',
     abbreviation: 'CON',
   },


### PR DESCRIPTION
## Summary

-  `Conneticut` -> `Connecticut`

## Screenshots or Videos (if applicable)

<img width="499" alt="Scout_-_Helping_you_to_navigate_the_world_of_Open_Data" src="https://user-images.githubusercontent.com/9020979/226147819-573548f3-9153-4f6e-bf47-42382a9ee482.png">

## Related Issues

N/A

## Test Plan

There should be no behavior change unless this field is used for joining data and not just a label. I think this should work since the string with the old spelling wasn't showing up anywhere else in github search.

## Checklist Before Requesting a Review

- [x] I have performed a self-review of my code
- [ ] My code follows the Style Guidelines and Best Practices outlined in the project wiki
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation, if applicable
- [ ] My change generates no new warnings or failed tests
- [ ] If it is a core feature, I have added thorough tests
- [ ] I have implemented analytics, if applicable

## Notes

- Spotted during the school of data [workshop](https://nycsodata23.sched.com/event/1JUZH/theres-a-dataset-for-that-discovering-and-visualizing-open-data-with-scout) today